### PR TITLE
Hide button and description for swap page

### DIFF
--- a/components/Home/CTA.tsx
+++ b/components/Home/CTA.tsx
@@ -62,7 +62,7 @@ export default function CallToAction() {
                             tutorial / lab classes of each course, giving you an
                             ordered list that you can copy into CourseReg.
                         </Text>
-                        <Text color={useColorModeValue("gray.700", "gray.300")}>
+                        <Text color={useColorModeValue("gray.700", "gray.300")} style={{display: "none"}}>
                             You can also request swaps for classes.
                         </Text>
                         <Text color={"gray.500"} mt={2}>
@@ -115,6 +115,7 @@ export default function CallToAction() {
                                     />
                                 }
                                 colorScheme="teal"
+                                style={{display: "none"}}
                             >
                                 Swap Classes
                             </Button>


### PR DESCRIPTION
Remove button and description for swap page

<img width="922" height="359" alt="image" src="https://github.com/user-attachments/assets/2917e684-0564-44c8-a42b-e6b5b5c8fbb9" />